### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ entire toolbox to calculate the fluxes, this smaller toolbox was created.
 <h4> Define transects and depth ranges </h4>
 You can define a list of transects you want the volume transport calculated for in the function
 <em>defineTransects()</em>.  The output from running is a comma separated value file containing the positive,
-negative, and net transport through the transect. You can also caluclate the transport for the e.g. just the upper
+negative, and net transport through the transect. You can also calculate the transport for the e.g. just the upper
 500 meters of the water column by defining the minimum and maximum depths:
 
 ```Python


### PR DESCRIPTION
@trondkr, I've corrected a typographical error in the documentation of the [romstools](https://github.com/trondkr/romstools) project. Specifically, I've changed caluclate to calculate. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
